### PR TITLE
Exclude Internet Explorer for the es6 build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,7 @@
                     "@babel/preset-env",
                     {
                         "modules": false,
-                        "targets": "defaults",
+                        "targets": "defaults and not IE 11",
                     }
                 ]
             ],


### PR DESCRIPTION
This disables a lot of transformations, most notably the transformation for classes.
I checked that this was properly picked up by the profiler using `yarn link`.