### PR TITLE
Change the selectedItem state to keep the index instead of the React element

### DIFF
--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -163,6 +163,15 @@ export default class AbstractMenu extends Component {
         this.setState({ selectedItem: null, forceSubMenuOpen: false });
     };
 
+    /**
+     * Render all the children.
+     * It has a `childIndexRef` parameter to be able to construct the child
+     * indexes properly. A reference was needed for this function because this
+     * is a recursive function that could mutate the index and pass it back to
+     * the caller. That parameter should always be undefined while calling from
+     * outside.
+     * TODO: Rewrite this function in a way that we don't need this reference.
+     */
     renderChildren = (children, childIndexRef = { value: -1 }) =>
         React.Children.map(children, (child) => {
             let currentChildIndexRef = childIndexRef;

--- a/src/AbstractMenu.js
+++ b/src/AbstractMenu.js
@@ -131,20 +131,31 @@ export default class AbstractMenu extends Component {
             return i === currentIndex ? null : i;
         }
 
-        const currentIndex = children.indexOf(selectedItem);
+        const currentIndex = selectedItem ? selectedItem.index : -1;
         const nextEnabledChildIndex = findNextEnabledChildIndex(currentIndex);
 
         if (nextEnabledChildIndex !== null) {
             this.setState({
-                selectedItem: children[nextEnabledChildIndex],
+                selectedItem: {
+                    index: nextEnabledChildIndex,
+                    // We need to know the type of the selected item, so we can
+                    // check it during render and tryToOpenSubMenu.
+                    type: children[nextEnabledChildIndex].type
+                },
                 forceSubMenuOpen: false
             });
         }
     };
 
-    onChildMouseMove = (child) => {
-        if (this.state.selectedItem !== child) {
-            this.setState({ selectedItem: child, forceSubMenuOpen: false });
+    onChildMouseMove = (child, itemIndex) => {
+        if (this.state.selectedItem === null || this.state.selectedItem.index !== itemIndex) {
+            this.setState({
+                selectedItem: {
+                    index: itemIndex,
+                    type: child.type
+                },
+                forceSubMenuOpen: false
+            });
         }
     };
 
@@ -152,29 +163,45 @@ export default class AbstractMenu extends Component {
         this.setState({ selectedItem: null, forceSubMenuOpen: false });
     };
 
-    renderChildren = children => React.Children.map(children, (child) => {
-        const props = {};
-        if (!React.isValidElement(child)) return child;
-        if ([MenuItem, this.getSubMenuType()].indexOf(child.type) < 0) {
-            // Maybe the MenuItem or SubMenu is capsuled in a wrapper div or something else
-            props.children = this.renderChildren(child.props.children);
+    renderChildren = (children, childIndexRef = { value: -1 }) =>
+        React.Children.map(children, (child) => {
+            let currentChildIndexRef = childIndexRef;
+            const props = {};
+            if (!React.isValidElement(child)) return child;
+
+            if ([MenuItem, this.getSubMenuType()].indexOf(child.type) < 0) {
+                // Maybe the MenuItem or SubMenu is capsuled in a wrapper div or something else
+                props.children = this.renderChildren(child.props.children, currentChildIndexRef);
+                return React.cloneElement(child, props);
+            }
+
+            // At this point we know that this is a menu item and we are going to
+            // render it. We need to increment the child index and assign it as
+            // the item index.
+            let itemIndex = null;
+            if (!child.props.divider) {
+                // A MenuItem can be a divider. Do not increment the value if it's.
+                itemIndex = ++currentChildIndexRef.value;
+            }
+
+            props.onMouseLeave = this.onChildMouseLeave.bind(this);
+            if (child.type === this.getSubMenuType()) {
+                // special props for SubMenu only
+                props.forceOpen = this.state.forceSubMenuOpen &&
+                    (this.state.selectedItem && this.state.selectedItem.index === itemIndex);
+                props.forceClose = this.handleForceClose;
+                props.parentKeyNavigationHandler = this.handleKeyNavigation;
+            }
+            if (!child.props.divider &&
+                (this.state.selectedItem && this.state.selectedItem.index === itemIndex)) {
+                // special props for selected item only
+                props.selected = true;
+                props.ref = (ref) => { this.seletedItemRef = ref; };
+                return React.cloneElement(child, props);
+            }
+
+            // onMouseMove is only needed for non selected items
+            props.onMouseMove = () => this.onChildMouseMove(child, itemIndex);
             return React.cloneElement(child, props);
-        }
-        props.onMouseLeave = this.onChildMouseLeave.bind(this);
-        if (child.type === this.getSubMenuType()) {
-            // special props for SubMenu only
-            props.forceOpen = this.state.forceSubMenuOpen && (this.state.selectedItem === child);
-            props.forceClose = this.handleForceClose;
-            props.parentKeyNavigationHandler = this.handleKeyNavigation;
-        }
-        if (!child.props.divider && this.state.selectedItem === child) {
-            // special props for selected item only
-            props.selected = true;
-            props.ref = (ref) => { this.seletedItemRef = ref; };
-            return React.cloneElement(child, props);
-        }
-        // onMouseMove is only needed for non selected items
-        props.onMouseMove = () => this.onChildMouseMove(child);
-        return React.cloneElement(child, props);
-    });
+        });
 }

--- a/tests/ContextMenu.test.js
+++ b/tests/ContextMenu.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ContextMenu from '../src/ContextMenu';
+import MenuItem from '../src/MenuItem';
 import { showMenu, hideMenu } from '../src/actions';
 
 describe('ContextMenu tests', () => {
@@ -192,6 +193,94 @@ describe('ContextMenu tests', () => {
             )
         );
         expect(onMouseLeave).toHaveBeenCalled();
+        component.unmount();
+    });
+
+    test('should select the proper menu items with down arrow', () => {
+        const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
+        const onHide = jest.fn();
+        const component = mount(
+            <ContextMenu id={data.id} onHide={onHide}>
+                <MenuItem onClick={jest.fn()}>Item 1</MenuItem>
+                <MenuItem onClick={jest.fn()}>Item 2</MenuItem>
+            </ContextMenu>
+        );
+        const downArrow = new window.KeyboardEvent('keydown', { keyCode: 40 });
+
+        showMenu(data);
+        // Check that it's visible and there is no selected item at first.
+        expect(component.state()).toEqual(
+            Object.assign(
+                { isVisible: true, forceSubMenuOpen: false, selectedItem: null },
+                data.position
+            )
+        );
+
+        // Select the first item with down arrow.
+        document.dispatchEvent(downArrow);
+        // Index 0 with MenuItem type should be selected.
+        expect(component.state().selectedItem).toEqual({
+            index: 0,
+            type: MenuItem
+        });
+
+        // Select the second item with down arrow.
+        document.dispatchEvent(downArrow);
+        // Index 1 with MenuItem type should be selected.
+        expect(component.state().selectedItem).toEqual({
+            index: 1,
+            type: MenuItem
+        });
+
+        // Select the next item. But since this was the last item, it should loop
+        // back to the first again.
+        document.dispatchEvent(downArrow);
+        // Index 0 with MenuItem type should be selected.
+        expect(component.state().selectedItem).toEqual({
+            index: 0,
+            type: MenuItem
+        });
+
+        component.unmount();
+    });
+
+    test('should select the proper menu items with up arrow', () => {
+        const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
+        const onHide = jest.fn();
+        const component = mount(
+            <ContextMenu id={data.id} onHide={onHide}>
+                <MenuItem onClick={jest.fn()}>Item 1</MenuItem>
+                <MenuItem onClick={jest.fn()}>Item 2</MenuItem>
+            </ContextMenu>
+        );
+        const upArrow = new window.KeyboardEvent('keydown', { keyCode: 38 });
+
+        showMenu(data);
+        // Check that it's visible and there is no selected item at first.
+        expect(component.state()).toEqual(
+            Object.assign(
+                { isVisible: true, forceSubMenuOpen: false, selectedItem: null },
+                data.position
+            )
+        );
+
+        // Select the previous item. But since there was nothing selected, it
+        // should loop back down to the last item.
+        document.dispatchEvent(upArrow);
+        // Index 1 with MenuItem type should be selected.
+        expect(component.state().selectedItem).toEqual({
+            index: 1,
+            type: MenuItem
+        });
+
+        // Select the first item with up arrow.
+        document.dispatchEvent(upArrow);
+        // Index 0 with MenuItem type should be selected.
+        expect(component.state().selectedItem).toEqual({
+            index: 0,
+            type: MenuItem
+        });
+
         component.unmount();
     });
 });

--- a/tests/ContextMenu.test.js
+++ b/tests/ContextMenu.test.js
@@ -313,7 +313,7 @@ describe('ContextMenu tests', () => {
             type: MenuItem
         });
 
-        // Press enter select it.
+        // Press enter to select it.
         document.dispatchEvent(enter);
         // The selected item should be preserved and not reset.
         expect(component.state().selectedItem).toEqual({

--- a/tests/ContextMenu.test.js
+++ b/tests/ContextMenu.test.js
@@ -283,4 +283,44 @@ describe('ContextMenu tests', () => {
 
         component.unmount();
     });
+
+    test('should preserve the selected item after an enter', () => {
+        const data = { position: { x: 50, y: 50 }, id: 'CORRECT_ID' };
+        const onHide = jest.fn();
+        const component = mount(
+            <ContextMenu id={data.id} onHide={onHide}>
+                <MenuItem onClick={jest.fn()} preventClose>Item 1</MenuItem>
+                <MenuItem divider />
+                <MenuItem onClick={jest.fn()} preventClose>Item 2</MenuItem>
+            </ContextMenu>
+        );
+        const upArrow = new window.KeyboardEvent('keydown', { keyCode: 38 });
+        const enter = new window.KeyboardEvent('keydown', { keyCode: 13 });
+
+        showMenu(data);
+        // Check that it's visible and there is no selected item at first.
+        expect(component.state()).toEqual(
+            Object.assign(
+                { isVisible: true, forceSubMenuOpen: false, selectedItem: null },
+                data.position
+            )
+        );
+
+        // Select the second item up arrow.
+        document.dispatchEvent(upArrow);
+        expect(component.state().selectedItem).toEqual({
+            index: 1,
+            type: MenuItem
+        });
+
+        // Press enter select it.
+        document.dispatchEvent(enter);
+        // The selected item should be preserved and not reset.
+        expect(component.state().selectedItem).toEqual({
+            index: 1,
+            type: MenuItem
+        });
+
+        component.unmount();
+    });
 });


### PR DESCRIPTION
This PR changes the selected item state to keep the index and type of the item instead of the React element itself. This is because when user presses enter, the context menu resets the selectedItem because the element itself changes.