### PR TITLE
Adding explicit children props to components

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,7 @@ declare module "@firefox-devtools/react-contextmenu" {
         preventHideOnResize?: boolean,
         preventHideOnScroll?: boolean,
         style?: React.CSSProperties,
+        children?: React.ReactNode,
     }
 
     export interface ContextMenuTriggerProps {
@@ -36,6 +37,7 @@ declare module "@firefox-devtools/react-contextmenu" {
         divider?: boolean,
         preventClose?: boolean,
         onClick?: {(event: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>, data: Object, target: HTMLElement): void} | Function,
+        children?: React.ReactNode,
     }
 
     export interface SubMenuProps {
@@ -46,6 +48,7 @@ declare module "@firefox-devtools/react-contextmenu" {
         rtl?: boolean,
         preventCloseOnClick?: boolean,
         onClick?: {(event: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>, data: Object, target: HTMLElement): void} | Function,
+        children?: React.ReactNode,
     }
 
     export interface ConnectMenuProps {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,7 +26,8 @@ declare module "@firefox-devtools/react-contextmenu" {
         renderTag?: React.ElementType,
         triggerOnLeftClick?: boolean,
         disableIfShiftIsPressed?: boolean,
-        [key: string]: any
+        [key: string]: any,
+        children?: React.ReactNode,
     }
 
     export interface MenuItemProps {


### PR DESCRIPTION
In React 18's types, the implicit children prop on functional components was removed, requiring that it be explicitly defined by developers; this change adds them to the library so that Typescript projects on React 18 can continue to import the library.