### PR TITLE
Documentation and cleaning up the publishing process

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,17 @@
+# Publishing a new version of this package
+
+1. run `yarn publish`. This will ask you the new version, login into npm, build
+   the package, commit and tag before pushing to npm.
+   If you want to stop at any moment, you can ctrl-c, and depending on the moment,
+   you'll need to rollback manually.
+2. On github, you need to edit the branch protection rules, and uncheck the
+   option "Do not allow bypassing the above settings".
+3. Then you can push to github with the tags: `git push upstream HEAD --tags`. This
+   is the only case you're allowed to push directly to github.
+4. Check the option "Do not allow bypassing the above settings" again.
+5. On github, go to the tags page, then create a new release from the new tag
+   (this is an option in the "..." menu at the right).
+6. Click "Generate releases notes" then follow the format of previous releases.
+
+
+

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:examples": "yarn clean:examples && yarn build:dev",
     "build:dev": "cross-env BABEL_ENV=es6 webpack --config examples/webpack.config.js --progress --profile",
     "start": "webpack serve --config examples/webpack.config.js",
-    "prepublishOnly": "yarn build"
+    "prepack": "yarn --frozen-lockfile && yarn build"
   },
   "author": "Vivek Kumar Bansal <contact@vkbansal.me>",
   "license": "MIT",


### PR DESCRIPTION
This adds some documentation about the publishing process.
This also changes the script `prepublishOnly` to `prepack` when publishing. Both are run currently so it's really a no-op, but I've noticed that more recent versions of yarn only does `prepack`, so this looks more correct.
I also updated the content of this script to make sure the dependencies are uptodate before building.