### PR TITLE
Fix type error for consumers on @types/react v19

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,7 @@ declare module "@firefox-devtools/react-contextmenu" {
     }
 
     export interface SubMenuProps {
-        title: React.ReactElement<any> | React.ReactText,
+        title: React.ReactElement<any> | string | number,
         attributes?: React.HTMLAttributes<HTMLDivElement>,
         className?: string,
         disabled?: boolean,


### PR DESCRIPTION
The fix is needed to be able to upgrade the [profiler](https://github.com/firefox-devtools/profiler) to React 19.

React.ReactText was removed from @types/react v19. It was an alias for string | number, so substitute the underlying types directly so the SubMenuProps.title declaration keeps compiling against both v18 and v19.